### PR TITLE
chore(deps): cap dependency version

### DIFF
--- a/git_clone_url.gemspec
+++ b/git_clone_url.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'uri-ssh_git'
+  spec.add_runtime_dependency 'uri-ssh_git', '>= 1.0', '< 2.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
`uri-ssh_git` will change api.
https://github.com/packsaddle/ruby-uri-ssh_git/issues/14
