### PR TITLE
feat(deps): update uri-ssh_git version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ GitCloneUrl.parse(git_url)
 #=> {scheme: 'git', host: 'github.com', path: '/schacon/ticgit.git' }
 GitCloneUrl.parse(ssh_url)
 #=> #<URI::SshGit::Generic git@github.com:schacon/ticgit.git>
-#=> {scheme: nil, user: 'git', userinfo: 'git', host: 'github.com', path: '/schacon/ticgit.git' }
+#=> {scheme: nil, user: 'git', userinfo: 'git', host: 'github.com', path: 'schacon/ticgit.git' }
 GitCloneUrl.parse(https_url)
 #=> #<URI::HTTPS https://github.com/schacon/ticgit.git>
 #=> {scheme: 'https', host: 'github.com', path: '/schacon/ticgit.git'}

--- a/example/simple.rb
+++ b/example/simple.rb
@@ -8,7 +8,7 @@ https_url_with_userinfo = 'https://user:pass@github.com/schacon/ticgit.git'
 GitCloneUrl.parse(git_url)
 #=> {scheme: 'git', host: 'github.com', path: '/schacon/ticgit.git' }
 GitCloneUrl.parse(ssh_url)
-#=> {scheme: nil, user: 'git', userinfo: 'git', host: 'github.com', path: '/schacon/ticgit.git' }
+#=> {scheme: nil, user: 'git', userinfo: 'git', host: 'github.com', path: 'schacon/ticgit.git' }
 GitCloneUrl.parse(https_url)
 #=> {scheme: 'https', host: 'github.com', path: '/schacon/ticgit.git'}
 GitCloneUrl.parse(https_url_with_userinfo)

--- a/git_clone_url.gemspec
+++ b/git_clone_url.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'uri-ssh_git', '>= 1.0', '< 2.0'
+  spec.add_runtime_dependency 'uri-ssh_git', '>= 2.0.rc', '< 3.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/test/test_git_clone_url.rb
+++ b/test/test_git_clone_url.rb
@@ -84,7 +84,7 @@ module GitCloneUrl
       end
       test 'ssh_url path' do
         assert do
-          ::GitCloneUrl.parse(ssh_url).path == '/schacon/ticgit.git'
+          ::GitCloneUrl.parse(ssh_url).path == 'schacon/ticgit.git'
         end
       end
     end


### PR DESCRIPTION
Breaking change

uri-ssh_git changes behavior.

v1 behavior: #parse always returns path which start with '/', and
Generic#to_s always returns path's first '/' stripped.
v2 behavior: #parse returns path which depends on input (absolute path
or relative path)

git_clone_url uses uri-ssh_git directly, so this changes git_clone_url
behavior.

https://github.com/packsaddle/ruby-git_clone_url/issues/6
https://github.com/packsaddle/ruby-uri-ssh_git/issues/14
